### PR TITLE
support wkt geom format and geom field alias

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,17 +5,31 @@ const processSelect = require('./select')
 
 exports.convertRequest = convertRequest
 
-function convertRequest (resource, querystrings) {
+/**
+ * Convert request to a Carto-compatible request
+ *
+ * @param {string} querystrings - Querystring portion of the request URL
+ * @param {Object} [opts]
+ * @param {string} [opts.dataset] - Socrata dataset id (ie. s9x7-we12)
+ * @param {string} [opts.geomFormat=geojson] - Geometry output format (wkt or geojson)
+ * @param {string} [opts.geomAlias=the_geom] - Alias for geometry field
+ * @return {string} Carto-compatible SQL query
+ */
+function convertRequest (querystrings, opts) {
+  opts = opts || {}
+  opts.geomFormat = opts.geomFormat || 'geojson'
+  opts.geomAlias = opts.geomAlias || 'the_geom'
+
   const ast = parser.parse(querystrings)
 
   // Process SELECT columns
-  ast.columns = processSelect(ast.columns)
+  ast.columns = processSelect(ast.columns, opts)
 
   // Add FROM to AST
-  if (resource) ast.from = [ { table: `"${resource}"` } ]
+  if (opts.dataset) ast.from = [ { table: `"${opts.dataset}"` } ]
 
   // Process WHERE recursively
-  if (ast.where) ast.where = processWhere(ast.where)
+  if (ast.where) ast.where = processWhere(ast.where, opts)
 
   // Convert AST back to SQL
   const sql = parser.stringify.parse(ast)

--- a/lib/select.js
+++ b/lib/select.js
@@ -1,9 +1,9 @@
 // SELECT processor
-module.exports = function (columns, geomFormat, geomAlias = 'the_geom') {
+module.exports = function (columns, opts) {
   let geomFunc
-  if (geomFormat === 'wkt') {
+  if (opts.geomFormat === 'wkt') {
     geomFunc = 'ST_AsText(the_geom)'
-  } else { // geojson
+  } else if (opts.geomFormat === 'geojson') {
     geomFunc = 'ST_AsGeoJSON(the_geom)::json'
   }
 
@@ -15,7 +15,7 @@ module.exports = function (columns, geomFormat, geomAlias = 'the_geom') {
       },
       {
         expr: { type: 'raw', value: geomFunc },
-        as: geomAlias
+        as: opts.geomAlias
       }
     ]
   } else {
@@ -24,7 +24,7 @@ module.exports = function (columns, geomFormat, geomAlias = 'the_geom') {
       if (col.expr.type === 'column_ref' && col.expr.column === 'the_geom') {
         // If explicitly selecting `the_geom`, wrap it in a format converter
         col.expr = { type: 'raw', value: geomFunc }
-        col.as = col.as || geomAlias
+        col.as = col.as || opts.geomAlias
       } else if (col.expr.type === 'aggr_func') {
         // PostGISify Socrata's convex_hull function
         if (col.expr.name === 'convex_hull') {

--- a/lib/select.js
+++ b/lib/select.js
@@ -1,31 +1,30 @@
 // SELECT processor
-module.exports = function (columns) {
+module.exports = function (columns, geomFormat, geomAlias = 'the_geom') {
+  let geomFunc
+  if (geomFormat === 'wkt') {
+    geomFunc = 'ST_AsText(the_geom)'
+  } else { // geojson
+    geomFunc = 'ST_AsGeoJSON(the_geom)::json'
+  }
+
   if (columns === '*') {
     // Convert `SELECT *` to `SELECT *, ST_AsGeoJSON(the_geom)::json AS the_geom`
     return [
       {
-        expr: {
-          type: 'star'
-        }
+        expr: { type: 'star' }
       },
       {
-        expr: {
-          type: 'raw',
-          value: 'ST_AsGeoJSON(the_geom)::json'
-        },
-        as: 'the_geom'
+        expr: { type: 'raw', value: geomFunc },
+        as: geomAlias
       }
     ]
   } else {
     // Explicit fields selected
     return columns.map(function (col) {
-      // Wrap any `the_geom` selections in `ST_AsGeoJSON(...)::json AS ...)`
       if (col.expr.type === 'column_ref' && col.expr.column === 'the_geom') {
-        col.expr = {
-          type: 'raw',
-          value: 'ST_AsGeoJSON(the_geom)::json'
-        }
-        col.as = col.as || 'the_geom'
+        // If explicitly selecting `the_geom`, wrap it in a format converter
+        col.expr = { type: 'raw', value: geomFunc }
+        col.as = col.as || geomAlias
       } else if (col.expr.type === 'aggr_func') {
         // PostGISify Socrata's convex_hull function
         if (col.expr.name === 'convex_hull') {

--- a/lib/where.js
+++ b/lib/where.js
@@ -1,5 +1,5 @@
 // Recursive WHERE processor
-module.exports = function (expr) {
+module.exports = function (expr, opts) {
   // If AND or OR, recurse
   if (expr.type === 'binary_expr' && (expr.operator === 'AND' || expr.operator === 'OR')) {
     expr.left = module.exports(expr.left)

--- a/server.js
+++ b/server.js
@@ -17,8 +17,11 @@ http.createServer((req, res) => router(req, res).pipe(res)).listen(port)
 
 function resourceHandler (req, res, params) {
   const query = url.parse(req.url, true).query
-  const sql = convertRequest(params.resource, query)
+  const opts = { dataset: params.resource }
+  const sql = convertRequest(query, opts)
   const cartoUrl = `${endpoint}sql?q=${sql}`
+
+  res.setHeader('Content-Type', 'application/json')
   return request(cartoUrl)
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ queries
   .forEach((query) => {
     test(query.label, (t) => {
       t.plan(1)
-      const sql = convertRequest(null, query.input)
+      const sql = convertRequest(query.input)
       t.equal(sql, query.expect)
     })
   })


### PR DESCRIPTION
Supports #5 and #7 by allowing the geometry format to be specified and the geometry field alias to be specified in the `SELECT` processor.

Still need to wrap this functionality in the main `lib/index.js` `convertRequest()` function without having a gigantic API.

EDIT: Perhaps geom format conversion should be disabled by default (unless explicitly set in `convertRequest()` call) at least for the sake of the tests?