### PR TITLE
Support csv/geojson downloads, enable cors

### DIFF
--- a/datasets.yml
+++ b/datasets.yml
@@ -1,0 +1,3 @@
+sspu-uyfa:
+  carto_table: incidents_part1_part2
+  geometry_field: shape

--- a/handler.js
+++ b/handler.js
@@ -1,6 +1,7 @@
 'use strict'
 const request = require('request')
 const url = require('url')
+const pick = require('lodash/pick')
 const convertRequest = require('./lib').convertRequest
 
 const cartoDomain = process.env.CARTO_DOMAIN
@@ -35,8 +36,14 @@ module.exports.soda = (event, context, callback) => {
   request(requestOpts, (err, response) => {
     if (err) return callback(err)
 
+    const headersToKeep = ['content-type', 'access-control-allow-origin', 'access-control-allow-headers']
     const payload = {
-      statusCode: response.statusCode
+      statusCode: response.statusCode,
+      headers: pick(response.headers, headersToKeep)
+    }
+    if (format !== 'json') {
+      // Only tell browser to download if it's not JSON
+      payload.headers['content-disposition'] = response.headers['content-disposition']
     }
 
     if (format === 'json' && response.statusCode === 200) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ exports.convertRequest = convertRequest
 function convertRequest (querystrings, opts) {
   opts = opts || {}
   opts.geomFormat = opts.geomFormat || 'geojson'
-  opts.geomAlias = opts.geomAlias || 'the_geom'
+  opts.geomAlias = opts.geomAlias || 'the_geom_' + opts.geomFormat // avoid conflict w/the_geom
 
   const ast = parser.parse(querystrings)
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "dotenv": "^2.0.0",
     "from2-string": "^1.1.0",
+    "lodash": "^4.17.4",
     "node-soda2-parser": "^2.0.0",
     "npm-watch": "^0.1.7",
     "request": "^2.76.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "dotenv": "^2.0.0",
     "from2-string": "^1.1.0",
+    "js-yaml": "^3.8.1",
     "lodash": "^4.17.4",
     "node-soda2-parser": "^2.0.0",
     "npm-watch": "^0.1.7",

--- a/serverless.yml
+++ b/serverless.yml
@@ -60,7 +60,10 @@ functions:
     handler: handler.soda
     timeout: 30
     events:
-      - http: GET resource/{resource}
+      - http:
+          path: resource/{resource}
+          method: get
+          cors: true
 
 #    The following are a few example events you can configure
 #    NOTE: Please make sure to change your handler code to work with those events

--- a/test/queries.js
+++ b/test/queries.js
@@ -1,4 +1,4 @@
-const star = '*, ST_AsGeoJSON(the_geom)::json AS the_geom'
+const star = '*, ST_AsGeoJSON(the_geom)::json AS the_geom_geojson'
 const limit = 'LIMIT 1000' // default limit per lib/index.js
 
 module.exports = [


### PR DESCRIPTION
- Changes the default "converted geometry" column name from `the_geom` to `the_geom_geojson` or `the_geom_wkt` (whichever is being used) to avoid postgres query conflicts with `the_geom`.
- Passes the `content-disposition` header through, which tells the browser to prompt a download, when the format being requested is not `json` (also passing `content-type` through)
- Enables CORS pre-flights via `serverless.yml` config and passes CORS headers through from carto response

closes #5, closes #6, closes #26 
