### PR TITLE
Adjust test to accommodate named filters being strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "from2-string": "^1.1.0",
     "js-yaml": "^3.8.1",
     "lodash": "^4.17.4",
-    "node-soda2-parser": "^2.0.0",
+    "node-soda2-parser": "^2.1.0",
     "npm-watch": "^0.1.7",
     "request": "^2.76.0",
     "server-router": "^3.0.0"

--- a/test/queries.js
+++ b/test/queries.js
@@ -51,7 +51,7 @@ module.exports = [
   {
     label: 'where: named filters with where clause',
     input: `foo=1&$where=bar = 2`,
-    expect: `SELECT ${star} WHERE bar = 2 AND foo = 1 ${limit}`
+    expect: `SELECT ${star} WHERE bar = 2 AND foo = '1' ${limit}`
   },
   {
     label: 'where: within box',

--- a/test/queries.js
+++ b/test/queries.js
@@ -46,7 +46,7 @@ module.exports = [
   {
     label: 'where: named filters set types',
     input: `foo=1&bar=quz`,
-    expect: `SELECT ${star} WHERE foo = 1 AND bar = 'quz' ${limit}`
+    expect: `SELECT ${star} WHERE foo = '1' AND bar = 'quz' ${limit}`
   },
   {
     label: 'where: named filters with where clause',


### PR DESCRIPTION
depends on timwis/node-soda2-parser#8 being merged and published on npm. Tests will fail until then.